### PR TITLE
Add `DELETE /tournament/{id}/players` endpoint

### DIFF
--- a/tournament/src/api/error_message.py
+++ b/tournament/src/api/error_message.py
@@ -27,3 +27,6 @@ NICKNAME_MISSING = 'Missing nickname field'
 NICKNAME_TOO_SHORT = f'Nickname must contain at least {settings.MIN_NICKNAME_LENGTH} characters'
 NICKNAME_TOO_LONG = f'Nickname must contain less than {settings.MAX_NICKNAME_LENGTH} characters'
 NICKNAME_INVALID_CHAR = 'Nickname may only contain letters, numbers and spaces'
+
+NOT_REGISTERED = 'You are not registered for this tournament'
+CANT_LEAVE = 'You can not leave this tournament'

--- a/tournament/src/api/tests/test_tournament_players.py
+++ b/tournament/src/api/tests/test_tournament_players.py
@@ -244,3 +244,101 @@ class PostTournamentPlayers(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(body['errors'], [error.PASSWORD_MISSING])
+
+
+class DeleteTournamentPlayers(TestCase):
+    def setUp(self):
+        tournament = Tournament.objects.create(id=1, name='tournament', admin_id=1, max_players=16)
+        Tournament.objects.create(id=2, name='tournament', admin_id=1, max_players=16)
+        Player.objects.create(nickname='player 1', user_id=1, tournament=tournament)
+        Player.objects.create(nickname='player 2', user_id=2, tournament=tournament)
+
+        finished_tournament = Tournament.objects.create(id=3, name='tournament', admin_id=1, status=2)
+        Player.objects.create(nickname='player 1', user_id=1, tournament=finished_tournament)
+
+        in_progress_tournament = Tournament.objects.create(id=4, name='tournament', admin_id=1, status=1)
+        Player.objects.create(nickname='player 1', user_id=1, tournament=in_progress_tournament)
+
+    @patch('api.views.tournament_players_views.authenticate_request')
+    def test_delete_tournament_player(self, mock_authenticate_request):
+        user = {'id': 1}
+        mock_authenticate_request.return_value = (user, None)
+        tournament_id = 1
+
+        url = reverse('tournament-players', args=(tournament_id,))
+        response = self.client.delete(url)
+
+        body = json.loads(response.content.decode('utf8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body['message'], 'You left the tournament `tournament`')
+
+    @patch('api.views.tournament_players_views.authenticate_request')
+    def test_delete_not_admin(self, mock_authenticate_request):
+        user = {'id': 2}
+        mock_authenticate_request.return_value = (user, None)
+        tournament_id = 1
+
+        url = reverse('tournament-players', args=(tournament_id,))
+        response = self.client.delete(url)
+
+        body = json.loads(response.content.decode('utf8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body['message'], 'You left the tournament `tournament`')
+
+    @patch('api.views.tournament_players_views.authenticate_request')
+    def test_delete_tournament_not_found(self, mock_authenticate_request):
+        user = {'id': 1}
+        mock_authenticate_request.return_value = (user, None)
+        tournament_id = 10
+
+        url = reverse('tournament-players', args=(tournament_id,))
+        response = self.client.delete(url)
+
+        body = json.loads(response.content.decode('utf8'))
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(body['errors'], [f'tournament with id `{tournament_id}` does not exist'])
+
+    @patch('api.views.tournament_players_views.authenticate_request')
+    def test_delete_not_registered(self, mock_authenticate_request):
+        user = {'id': 1}
+        mock_authenticate_request.return_value = (user, None)
+        tournament_id = 2
+
+        url = reverse('tournament-players', args=(tournament_id,))
+        response = self.client.delete(url)
+
+        body = json.loads(response.content.decode('utf8'))
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(body['errors'], ['You are not registered for this tournament'])
+
+    @patch('api.views.tournament_players_views.authenticate_request')
+    def test_delete_finished_tournament(self, mock_authenticate_request):
+        user = {'id': 1}
+        mock_authenticate_request.return_value = (user, None)
+        tournament_id = 3
+
+        url = reverse('tournament-players', args=(tournament_id,))
+        response = self.client.delete(url)
+
+        body = json.loads(response.content.decode('utf8'))
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(body['errors'], [error.CANT_LEAVE])
+
+    @patch('api.views.tournament_players_views.authenticate_request')
+    def test_delete_in_progress_tournament(self, mock_authenticate_request):
+        user = {'id': 1}
+        mock_authenticate_request.return_value = (user, None)
+        tournament_id = 4
+
+        url = reverse('tournament-players', args=(tournament_id,))
+        response = self.client.delete(url)
+
+        body = json.loads(response.content.decode('utf8'))
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(body['errors'], [error.CANT_LEAVE])

--- a/tournament/src/api/views/tournament_players_views.py
+++ b/tournament/src/api/views/tournament_players_views.py
@@ -85,6 +85,36 @@ class TournamentPlayersView(View):
         return JsonResponse(model_to_dict(player), status=201)
 
     @staticmethod
+    def delete(request: HttpRequest, tournament_id: int):
+        user, authenticate_errors = authenticate_request(request)
+        if user is None:
+            return JsonResponse(data={'errors': authenticate_errors}, status=401)
+
+        try:
+            tournament = Tournament.objects.get(id=tournament_id)
+        except ObjectDoesNotExist:
+            return JsonResponse({'errors': [f'tournament with id `{tournament_id}` does not exist']}, status=404)
+        except Exception as e:
+            return JsonResponse({'errors': [str(e)]}, status=500)
+
+        try:
+            player = tournament.players.get(user_id=user['id'])
+        except ObjectDoesNotExist:
+            return JsonResponse({'errors': [error.NOT_REGISTERED]}, status=404)
+        except Exception as e:
+            return JsonResponse({'errors': [str(e)]}, status=500)
+
+        if tournament.status != Tournament.CREATED:
+            return JsonResponse({'errors': [error.CANT_LEAVE]}, status=403)
+
+        try:
+            player.delete()
+        except Exception as e:
+            return JsonResponse({'errors': [str(e)]}, status=500)
+
+        return JsonResponse({'message': f'You left the tournament `{tournament.name}`'}, status=200)
+
+    @staticmethod
     def is_valid_nickname(nickname: str) -> tuple[bool, Optional[list[str]]]:
         errors = []
 

--- a/tournament/src/tournament/settings.py
+++ b/tournament/src/tournament/settings.py
@@ -130,7 +130,7 @@ else:
                 'NAME': 'mydatabase',
                 'USER': 'myuser',
                 'PASSWORD': 'mypassword',
-                'HOST': 'user-management-db',
+                'HOST': 'tournament-db',
                 'PORT': '5432',
             }
         }


### PR DESCRIPTION
It is now possible to leave a tournament while it is still in the registration phase (status=CREATED).