### PR TITLE
Fixed OAuth crash

### DIFF
--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -48,7 +48,7 @@ this documentation details the different endpoints of each microservice.
 > ### [/user/username-exist](../user_management/doc/User_management.md#username-exist)
 
 > ### [/user/email-exist](../user_management/doc/User_management.md#email-exist)
-> 
+
 > ### [/user/forgot-password/send-code](../user_management/doc/User_management.md#forgot-passwordsend-code)
 
 > ### [/user/forgot-password/check-code](../user_management/doc/User_management.md#forgot-passwordcheck-code)
@@ -57,9 +57,9 @@ this documentation details the different endpoints of each microservice.
 
 > ### [/user/refresh-access-jwt](../user_management/doc/User_management.md#refresh-access-jwt)
 
-> ### [/user/{user_id}](../user_management/doc/User_management.md#useruser-id)
+> ### [/user/{user_id}](../user_management/doc/User_management.md#user-id)
 
-> ### [/search-username/](../user_management/doc/User_management.md#search-username)
+> ### [/user/search-username/](../user_management/doc/User_management.md#search-username)
 
 > ### [/user/oauth/{oauth-service}](../user_management/doc/User_management.md#oauthoauth-service)
 

--- a/user_management/doc/User_management.md
+++ b/user_management/doc/User_management.md
@@ -2,7 +2,7 @@
 
 --------------------------------------------------------------------------------
 
-## `signup`
+## `/user/signup/`
 
 ### Account creation
 
@@ -60,7 +60,7 @@ all fields are mandatory
 </details>
 
 
-## `signin`
+## `/user/signin/`
 
 ### User connection
 
@@ -103,7 +103,7 @@ all fields are mandatory
 </details>
 
 
-## `username-exist`
+## `/user/username-exist/`
 
 ### Check if username is already taken
 
@@ -142,7 +142,7 @@ will return a boolean
 
 </details>
 
-## `email-exist`
+## `/user/email-exist/`
 
 ### Check if email is already taken
 
@@ -181,7 +181,7 @@ will return a boolean
 </details>
 
 
-## `refresh-access-jwt`
+## `/user/refresh-access-jwt/`
 
 ### Trade a valid refresh token for an access token
 
@@ -222,7 +222,7 @@ all fields are mandatory
 </details>
 
 
-## `forgot-password/send-code`
+## `/user/forgot-password/send-code/`
 
 ### Send a code to the user's email
 
@@ -259,7 +259,7 @@ all fields are mandatory
 
 </details>
 
-## `forgot-password/check-code`
+## `/user/forgot-password/check-code/`
 
 ### Verify the code sent by email
 
@@ -301,7 +301,7 @@ all fields are mandatory
 </details>
 
 
-## `forgot-password/change-password`
+## `/user/forgot-password/change-password/`
 
 ### Change the password of the user with the given code
 
@@ -327,7 +327,7 @@ all fields are mandatory
 </details>
 
 
-## `user/{user-id}`
+## `/user/{user-id}/`
 ### Get user non-sensitive information
 
 will return a user object when successful
@@ -367,14 +367,14 @@ Might be extended to return more information in the future, if needed
 
 </details>
 
-## `search-username`
+## `/user/search-username/`
 
 ### Search for a username
 
 will return a list of usernames that contains the searched username
 
 <details>
- <summary><code>POST</code><code><b>/search-username/</b></code></summary>
+ <summary><code>POST</code><code><b>/user/search-username/</b></code></summary>
 
 ### Parameters
 
@@ -405,20 +405,20 @@ will return a list of usernames that contains the searched username
 </details>
 
 
-## `oauth/{oauth-service}`
+## `/user/oauth/{oauth-service}/`
 ### Initiate OAuth authentication for the specified service
 
 This endpoint initiates the OAuth authentication process for the specified authentication service.
 It returns a redirection URL to the OAuth service's authorization endpoint.
 <details>
- <summary><code>GET</code><code><b>/oauth/{auth_service}/</b></code></summary>
+ <summary><code>GET</code><code><b>/user/oauth/{auth_service}/</b></code></summary>
 
 ### Parameters
 
 #### In the URL (mandatory)
  {auth_service}
 > 
-> NB: `auth_service` must be one of the following values: 'github', 'local-test', '42api'
+> NB: `auth_service` must be one of the following values: 'github', '42api'
 > 
 #### Responses
 
@@ -429,13 +429,13 @@ It returns a redirection URL to the OAuth service's authorization endpoint.
 
 </details>
 
-## `oauth/callback/{auth-service}`
+## `/user/oauth/callback/{auth-service}/`
 ### OAuth Callback for the specified service
 
 This endpoint handles the callback after successful OAuth authentication and retrieves the user's information.
 
 <details>
- <summary><code>GET</code><code><b>/oauth/callback/{auth_service}/</b></code></summary>
+ <summary><code>GET</code><code><b>/user/oauth/callback/{auth_service}/</b></code></summary>
 
 ### Parameters
 

--- a/user_management/src/user/urls.py
+++ b/user_management/src/user/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls.static import static
 from django.urls import path
 
-from user.views.OAuth import BaseOAuth, OAuthCallback
+from user.views.OAuth import OAuth, OAuthCallback
 from user.views.views import (ForgotPasswordChangePasswordView,
                               ForgotPasswordCheckCodeView,
                               ForgotPasswordSendCodeView, IsEmailTakenView,
@@ -21,8 +21,8 @@ urlpatterns = [
     path('forgot-password/change-password/', ForgotPasswordChangePasswordView.as_view(),
          name='forgot-password-change-password'),
     path('search-username/', SearchUsernameView.as_view(), name='search-username'),
-    path('oauth/<str:auth_service>', BaseOAuth.as_view(), name='oauth'),
-    path('oauth/callback/<str:auth_service>', OAuthCallback.as_view(), name='oauth-callback'),
+    path('oauth/<str:auth_service>/', OAuth.as_view(), name='oauth'),
+    path('oauth/callback/<str:auth_service>/', OAuthCallback.as_view(), name='oauth-callback'),
     path('<str:user_id>/', UserIdView.as_view(), name='user-id')
 ]
 

--- a/user_management/src/user/views/OAuth.py
+++ b/user_management/src/user/views/OAuth.py
@@ -25,14 +25,7 @@ class OAuthFactory:
             return None
 
 
-class BaseOAuth(View, ABC):
-    @staticmethod
-    def get(request, auth_service):
-        oauth_handler = OAuthFactory.create_oauth_handler(auth_service)
-        if oauth_handler:
-            return oauth_handler.handle_auth(request)
-        else:
-            return JsonResponse(data={'errors': ['Unknown auth service']}, status=400)
+class BaseOAuth(ABC):
 
     @staticmethod
     def create_pending_oauth():
@@ -44,6 +37,17 @@ class BaseOAuth(View, ABC):
     @abstractmethod
     def handle_auth(self, request):
         pass
+
+
+class OAuth(View):
+
+    @staticmethod
+    def get(request, auth_service):
+        oauth_handler = OAuthFactory.create_oauth_handler(auth_service)
+        if oauth_handler:
+            return oauth_handler.handle_auth(request)
+        else:
+            return JsonResponse(data={'errors': ['Unknown auth service']}, status=400)
 
 
 class GitHubOAuth(BaseOAuth):


### PR DESCRIPTION
*Moved the "get" definition method OUTSIDE the BaseOAuth because BaseOAuth is abstract (so it cannot be instanced !.. )

*Fix the documentation :
Now, all of my endpoints begin with "/user/". I think it'll be less ambiguous and more consistent