### PR TITLE
refactor matchmaking

### DIFF
--- a/matchmaking/docker/requirements.txt
+++ b/matchmaking/docker/requirements.txt
@@ -4,12 +4,15 @@ async-timeout==4.0.3
 attrs==23.2.0
 bidict==0.22.1
 certifi==2023.11.17
+cffi==1.16.0
 charset-normalizer==3.3.2
 colorlog==6.8.0
+cryptography==42.0.2
 frozenlist==1.4.1
 h11==0.14.0
 idna==3.6
 multidict==6.0.4
+pycparser==2.21
 PyJWT==2.8.0
 python-engineio==4.8.2
 python-socketio==5.11.0

--- a/matchmaking/src/authenticate.py
+++ b/matchmaking/src/authenticate.py
@@ -1,53 +1,53 @@
-import logging
 from typing import Optional
 
 import jwt
 import requests
-
 import src.settings as settings
 
 
 def authenticate_user(auth: str) -> (Optional[dict], list):
-    errors = []
     if auth is None:
-        errors.append('`auth` field is missing')
-        return None, errors
+        return None, '`auth` field is missing'
     token = auth.get('token')
     if token is None:
-        errors.append('`token` field is missing')
-        return None, errors
-    logging.debug(f'token: {token}')
-    payload = decode_jwt(token, errors)
-    logging.debug(f'payload: {payload}')
-    if payload is None:
-        return None, errors
+        return None, '`token` field is missing'
+    valid, payload, error_msg = decode_jwt(token)
+    if not valid:
+        return None, error_msg
     user_id = payload.get('user_id')
     if user_id is None:
-        return None, errors
-    user = get_user(user_id, token, errors)
+        return None, '`user_id` field is missing'
+    valid, elo, error = request_user_elo(user_id, token)
+    if not valid:
+        return None, error
+    user = {
+        'id': user_id,
+        'elo': elo,
+    }
     return user, None
 
 
-def decode_jwt(token: str, error: list) -> Optional[dict]:
+def decode_jwt(token: str) -> (bool, Optional[dict], Optional[str]):
     try:
         payload = jwt.decode(
             token,
             settings.ACCESS_KEY,
             algorithms=[settings.DECODE_ALGORITHM],
         )
-        return payload
+        return True, payload, None
     except Exception as e:
-        error.append(str(e))
-        return None
+        return False, None, str(e)
 
 
-def get_user(user_id: int, token: str, error: list) -> Optional[dict]:
-    headers = {'Authorization': token}
+def request_user_elo(user_id: int, token: str) -> (bool, Optional[int], Optional[str]):
+    headers = {
+        'Authorization': token,
+    }
     try:
-        response = requests.get(f'{settings.USER_MANAGEMENT_USER_ENDPOINT}{user_id}', headers=headers)
-    except Exception as e:
-        error.append(str(e))
-        return None
-    if response.status_code == 200:
-        return response.json()
-    return None
+        response = requests.get(f'{settings.USER_STATS_USER_ENDPOINT}{user_id}/', headers=headers)
+    except requests.exceptions.RequestException:
+        return False, None, 'Could not connect to user stats'
+    if not response.ok:
+        return False, None, 'Could not get user elo'
+    user_data = response.json()
+    return True, user_data.get('elo'), None

--- a/matchmaking/src/authenticate.py
+++ b/matchmaking/src/authenticate.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import jwt
 import requests
+
 import src.settings as settings
 
 

--- a/matchmaking/src/logging.py
+++ b/matchmaking/src/logging.py
@@ -1,7 +1,6 @@
 import logging
 
 from colorlog import ColoredFormatter
-
 import src.settings as settings
 
 

--- a/matchmaking/src/logging.py
+++ b/matchmaking/src/logging.py
@@ -1,6 +1,7 @@
 import logging
 
 from colorlog import ColoredFormatter
+
 import src.settings as settings
 
 

--- a/matchmaking/src/matchmaking.py
+++ b/matchmaking/src/matchmaking.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from aiohttp import web
 import socketio
+
 import src.settings as settings
 
 from .authenticate import authenticate_user

--- a/matchmaking/src/matchmaking.py
+++ b/matchmaking/src/matchmaking.py
@@ -4,8 +4,8 @@ import logging
 from time import time
 from typing import Optional
 
-from aiohttp import web
 import socketio
+from aiohttp import web
 
 import src.settings as settings
 

--- a/matchmaking/src/matchmaking.py
+++ b/matchmaking/src/matchmaking.py
@@ -4,9 +4,8 @@ import logging
 from time import time
 from typing import Optional
 
-import socketio
 from aiohttp import web
-
+import socketio
 import src.settings as settings
 
 from .authenticate import authenticate_user
@@ -28,7 +27,6 @@ class Matchmaking:
         self.sio.attach(self.app)
         self.sio.on('connect')(self.connect)
         self.sio.on('disconnect')(self.disconnect)
-        self.sio.on('queue_join')(self.queue_join)
         self.sio.on('queue_info')(self.queue_info)
         self.app.on_startup.append(self.start_matchmaking)
 
@@ -98,26 +96,20 @@ class Matchmaking:
         if user is None:
             logging.debug(str(errors))
             raise socketio.exceptions.ConnectionRefusedError(str(errors))
-        logging.debug(f'Authenticated user: {user}')
+        player = {
+            'sid': sid,
+            'user_id': user['id'],
+            'elo': user['elo'],
+            'timestamp': time(),
+        }
+        self.queue.append(player)
+        logging.debug(f'User added to the queue: {user}')
         return True
 
     def disconnect(self, sid):
         for user in self.queue:
             if user.get('sid') == sid:
                 self.queue.remove(user)
-
-    def queue_join(self, sid, data):
-        user_id = data.get('user_id')
-        elo = data.get('elo')
-        if elo is None or user_id is None:
-            self.sio.disconnect(sid)
-        player = {
-            'sid': sid,
-            'user_id': user_id,
-            'elo': elo,
-            'timestamp': time(),
-        }
-        self.queue.append(player)
 
     async def queue_info(self, sid, data):
         await self.sio.emit('queue_info', json.dumps(self.queue), room=sid)

--- a/matchmaking/src/settings.py
+++ b/matchmaking/src/settings.py
@@ -1,6 +1,6 @@
 import logging
 
-DEBUG = True
+DEBUG = False
 
 if DEBUG:
     LOG_LEVEL = logging.DEBUG

--- a/matchmaking/src/settings.py
+++ b/matchmaking/src/settings.py
@@ -1,6 +1,5 @@
 import logging
 
-
 DEBUG = True
 
 if DEBUG:

--- a/matchmaking/src/settings.py
+++ b/matchmaking/src/settings.py
@@ -1,10 +1,31 @@
 import logging
 
-LOG_LEVEL = logging.INFO
-ACCESS_KEY = 'django-insecure-&r*!icx1$(sv7f-sj&ezvjxw+pljt-yz(r6yowfg18ihdu@15k'
-DECODE_ALGORITHM = 'HS256'
-USER_MANAGEMENT_URL = 'http://user-management-nginx/'
-USER_MANAGEMENT_USER_ENDPOINT = USER_MANAGEMENT_URL + 'user/'
+
+DEBUG = True
+
+if DEBUG:
+    LOG_LEVEL = logging.DEBUG
+else:
+    LOG_LEVEL = logging.INFO
+
+if DEBUG:
+    USER_STATS_URL = 'http://localhost:8000/'
+else:
+    USER_STATS_URL = 'http://user-management-nginx/'
+
+USER_STATS_USER_ENDPOINT = USER_STATS_URL + 'statistics/user/'
+
+ACCESS_KEY = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl88VVar5X6lAlHjj4o4r
+r3WoAQloSNbxjgyUd6dU3z3a8JbLibihyl/LjrfAJXCT39FzBbjcWHw7dnDkBeU0
+xX8pPNESkfJI7wxzkc1WcPk1KMwvy1dTaoCub7fZxNl2oOObdzTGpic8co7VOUqa
+5cJks3MTL/8ipxaf4HVJ4luvcySvPflL1woWO3QfTomL/B/Xnu9fmj2ynn8DptfY
+wJEe4eFA/jx+TP3coPBgs/XYG3stdyislm574U+5QvfRi1uii8jkFgpIxwUnxYbx
+mZW+X8IdGmaUnucNeF1pLZjEIcr7MkzP3zm1auQww71DObGTPaLLJNjTPdP3rWYJ
+mQIDAQAB
+-----END PUBLIC KEY-----"""
+DECODE_ALGORITHM = 'RS256'
+
 QUEUE_MAX_TIME = 60
 ELO_MAX_THRESHOLD = 10000
 MATCHMAKING_PORT = 3000

--- a/matchmaking/test/test.py
+++ b/matchmaking/test/test.py
@@ -1,5 +1,5 @@
-import unittest
 from time import time
+import unittest
 
 from src.matchmaking import Matchmaking
 


### PR DESCRIPTION
This PR refactor the matchmaking to:
- Enhance the authentication be able to authenticate the tokens generated by user-management
- Add the player to the queue when connecting
- Fetch the user elo to `user-stats` microservice