### PR TITLE
Fix internal requests

### DIFF
--- a/.github/workflows/user_management.yaml
+++ b/.github/workflows/user_management.yaml
@@ -39,6 +39,11 @@ jobs:
         pip install isort
         pip install -r user_management/docker/requirements.txt
 
+    - name: Copy common
+      working-directory: user_management/src/
+      run: |
+        cp -r ../../common .
+
     - name: Run PEP8 check
       working-directory: user_management/src/
       run: |
@@ -48,11 +53,6 @@ jobs:
       working-directory: user_management/src/
       run: |
         isort . --check-only
-
-    - name: Copy common
-      working-directory: user_management/src/
-      run: |
-        cp -r ../../common .
 
     - name: Run Django migrations
       working-directory: user_management/src/

--- a/common/src/internal_requests.py
+++ b/common/src/internal_requests.py
@@ -1,0 +1,29 @@
+import requests
+
+
+class InternalRequests:
+
+    @staticmethod
+    def post(url, data=None, json=None, **kwargs):
+        kwargs.setdefault('verify', False)
+        return requests.post(url, data=data, json=json, **kwargs)
+
+    @staticmethod
+    def get(url, **kwargs):
+        kwargs.setdefault('verify', False)
+        return requests.get(url, **kwargs)
+
+    @staticmethod
+    def put(url, data=None, **kwargs):
+        kwargs.setdefault('verify', False)
+        return requests.put(url, data=data, **kwargs)
+
+    @staticmethod
+    def delete(url, **kwargs):
+        kwargs.setdefault('verify', False)
+        return requests.delete(url, **kwargs)
+
+    @staticmethod
+    def patch(url, data=None, **kwargs):
+        kwargs.setdefault('verify', False)
+        return requests.patch(url, data=data, **kwargs)

--- a/common/src/settings.py
+++ b/common/src/settings.py
@@ -11,7 +11,7 @@ ACCESS_ALGORITHM = 'RS256'
 
 USER_MANAGEMENT_URL = 'https://user-management-nginx/'
 
-USER_STATS_URL = 'http://user-stats-nginx/'
+USER_STATS_URL = 'https://user-stats-nginx/'
 DEBUG_USER_STATS_URL = 'http://localhost:8001/'
 
 USER_STATS_USER_ENDPOINT = USER_STATS_URL + 'statistics/user/'

--- a/user_management/docker/docker-compose.yaml
+++ b/user_management/docker/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
 
     user-management:
         networks:
+            - transcendence
             - user_management
         build:
             context: .

--- a/user_management/src/user/views/sign_up.py
+++ b/user_management/src/user/views/sign_up.py
@@ -1,6 +1,7 @@
 import json
 
 import common.src.settings as common
+from common.src.internal_requests import InternalRequests
 import requests
 from django.http import JsonResponse
 from django.utils.decorators import method_decorator
@@ -43,9 +44,11 @@ class SignUpView(View):
     def post_user_stats(user_id: int) -> (bool, list):
         try:
             if settings.DEBUG:
-                response = requests.post(f'{common.DEBUG_USER_STATS_USER_ENDPOINT}{user_id}/', data=json.dumps({}))
+                response = InternalRequests.post(f'{common.DEBUG_USER_STATS_USER_ENDPOINT}{user_id}/',
+                                                 data=json.dumps({}))
             else:
-                response = requests.post(f'{common.USER_STATS_USER_ENDPOINT}{user_id}/', data=json.dumps({}))
+                response = InternalRequests.post(f'{common.USER_STATS_USER_ENDPOINT}{user_id}/',
+                                                 data=json.dumps({}))
         except requests.exceptions.RequestException:
             return False, ['Could not access user-stats']
         if not response.ok:

--- a/user_management/src/user/views/sign_up.py
+++ b/user_management/src/user/views/sign_up.py
@@ -1,13 +1,13 @@
 import json
 
-import common.src.settings as common
-from common.src.internal_requests import InternalRequests
 import requests
 from django.http import JsonResponse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
+import common.src.settings as common
+from common.src.internal_requests import InternalRequests
 from user.models import User
 from user_management import settings
 from user_management.JWTManager import UserRefreshJWTManager

--- a/user_management/src/user/views/two_fa.py
+++ b/user_management/src/user/views/two_fa.py
@@ -2,12 +2,12 @@ import json
 
 import pyotp
 import qrcode
-from common.src.jwt_managers import user_authentication
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
+from common.src.jwt_managers import user_authentication
 from user.models import User
 from user_management.JWTManager import get_user_id
 

--- a/user_management/src/user_management/JWTManager.py
+++ b/user_management/src/user_management/JWTManager.py
@@ -1,11 +1,11 @@
 import base64
 import json
 
-import common.src.settings as common_settings
-from common.src.jwt_managers import JWTManager, UserAccessJWTDecoder
 from django.conf import settings
 from django.http import HttpRequest
 
+import common.src.settings as common_settings
+from common.src.jwt_managers import JWTManager, UserAccessJWTDecoder
 from user.models import User
 
 


### PR DESCRIPTION
- Fix errors on internal requests with SSL certificate.
- Now you need to use the InternalRequests class in common.

This implementation allows you to disable certificate verification.
In our case, we need this because we're making internal requests using docker DNS, but SSL certificates are only valid for localhost and not for docker DNS.
