### PR TITLE
Refactor match

### DIFF
--- a/user_stats/doc/user-stats-documentation.md
+++ b/user_stats/doc/user-stats-documentation.md
@@ -307,7 +307,7 @@
 > | `loser_id`     | int    | None    | Loser id                | Required    |
 > | `winner_score` | int    | None    | Winner score            | Required    |
 > | `loser_score`  | int    | None    | Loser score             | Required    |
-> | `date`         | String | None    | ISO 8601 formatted date | Required    |
+> | `date`         | String | None    | ISO 8601 formatted date | Optional    |
 
 ### Response
 

--- a/user_stats/src/api/tests/test_user_history.py
+++ b/user_stats/src/api/tests/test_user_history.py
@@ -115,7 +115,6 @@ class GetHistory(HistoryTest):
             'loser_id': 2,
             'winner_score': 10,
             'loser_score': 8,
-            'date': '2020-01-01T00:00:00+00:00',
         }
         for i in range(20):
             self.post_match(body)

--- a/user_stats/src/api/views/match.py
+++ b/user_stats/src/api/views/match.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Optional
 
+from django.utils import timezone
 from dateutil import parser
 from django.http import HttpRequest, JsonResponse
 from django.utils.decorators import method_decorator
@@ -81,6 +82,9 @@ class MatchView(View):
         user_score = json_body['winner_score'] if result else json_body['loser_score']
         opponent_score = json_body['loser_score'] if result else json_body['winner_score']
         opponent_id = json_body['loser_id'] if result else json_body['winner_id']
+        date = json_body.get('date')
+        date = parser.isoparse(date) if date is not None else timezone.now()
+
 
         match.user = user
         match.opponent = User.objects.get(pk=opponent_id)
@@ -91,8 +95,8 @@ class MatchView(View):
         match.user_win_rate = user.win_rate
         match.user_matches_played = user.matches_played
         match.user_friends = user.friends
-        match.date = parser.isoparse(json_body['date'])
         match.user_expected_result = MatchView.calculate_expected_result(user.elo, match.opponent.elo) * 100
+        match.date = date
         return match
 
     @staticmethod
@@ -149,10 +153,17 @@ class MatchView(View):
     @staticmethod
     def validate_date(date: Any) -> (bool, Optional[str]):
         if date is None:
-            return False, error.DATE_REQUIRED
+            return True, None
         try:
-            if parser.isoparse(date) is None:
+            date = parser.isoparse(date)
+            if date is None:
                 return False, error.DATE_INVALID
         except ValueError:
             return False, error.DATE_INVALID
+        try:
+            last_match = Match.objects.latest('date')
+            if date < last_match.date:
+                return False, error.DATE_INVALID
+        except Match.DoesNotExist:
+            pass
         return True, None

--- a/user_stats/src/api/views/match.py
+++ b/user_stats/src/api/views/match.py
@@ -91,8 +91,8 @@ class MatchView(View):
         match.user_win_rate = user.win_rate
         match.user_matches_played = user.matches_played
         match.user_friends = user.friends
-        match.user_expected_result = MatchView.calculate_expected_result(user.elo, match.opponent.elo)
         match.date = parser.isoparse(json_body['date'])
+        match.user_expected_result = MatchView.calculate_expected_result(user.elo, match.opponent.elo) * 100
         return match
 
     @staticmethod

--- a/user_stats/src/api/views/match.py
+++ b/user_stats/src/api/views/match.py
@@ -1,9 +1,9 @@
 import json
 from typing import Any, Optional
 
-from django.utils import timezone
 from dateutil import parser
 from django.http import HttpRequest, JsonResponse
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
@@ -84,7 +84,6 @@ class MatchView(View):
         opponent_id = json_body['loser_id'] if result else json_body['winner_id']
         date = json_body.get('date')
         date = parser.isoparse(date) if date is not None else timezone.now()
-
 
         match.user = user
         match.opponent = User.objects.get(pk=opponent_id)


### PR DESCRIPTION
- date in `statistics/match/` request body is now optional
- match can not be posted with a date prior to another match
- user_expected_result is now a percentage