### PR TITLE
Fix notification on user disconnection

### DIFF
--- a/notification/src/api/consumers.py
+++ b/notification/src/api/consumers.py
@@ -12,7 +12,6 @@ from common.src.jwt_managers import UserAccessJWTDecoder
 from notification import settings
 
 
-# TODO: the customer must send each new jwt
 class NotificationConsumer(AsyncWebsocketConsumer):
     async def connect(self):
         query_string = self.scope['query_string']
@@ -42,7 +41,8 @@ class NotificationConsumer(AsyncWebsocketConsumer):
             if len(group_channels) == 0:
                 friend_list = await self.get_friend_list(self.jwt)
                 for friend in friend_list:
-                    await self.send_user_status(int(self.group_name), friend['id'], 'offline')
+                    if friend['status'] == 'accepted':
+                        await self.send_user_status(int(self.group_name), friend['id'], 'offline')
 
     async def receive(self, text_data):
         try:


### PR DESCRIPTION
Fix the following problem
* user1 sends a friend request to user 2
* user2 doesn't respond immediately to the friend request
* meanwhile user1 refreshes his page (and thus reconnects to the socket notification)
* BUG: user2 has a new friend (user1) who pops offline even though he hasn't yet accepted the request