### PR TITLE
Add service authentication for updating tournament matches

### DIFF
--- a/notification/src/notification/settings.py
+++ b/notification/src/notification/settings.py
@@ -60,7 +60,6 @@ INSTALLED_APPS = [
     'api',
 ]
 
-# TODO: Add corsheaders
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/tournament/src/api/tests/test_tournament_matches.py
+++ b/tournament/src/api/tests/test_tournament_matches.py
@@ -192,7 +192,9 @@ class StartMatchTest(TestCase):
         tournament.status = Tournament.IN_PROGRESS
         tournament.save()
 
-    def start_match(self, tournament_id, player1, player2):
+    @patch('common.src.jwt_managers.ServiceAccessJWT.authenticate')
+    def start_match(self, tournament_id, player1, player2, mock_authenticate):
+        mock_authenticate.return_value = (True, None)
         url = reverse('start-match', args=(tournament_id,))
 
         response = self.client.post(
@@ -275,7 +277,10 @@ class EndMatchTest(TestCase):
         tournament.status = Tournament.IN_PROGRESS
         tournament.save()
 
-    def end_match(self, tournament_id, winner_id):
+    @patch('common.src.jwt_managers.ServiceAccessJWT.authenticate')
+    def end_match(self, tournament_id, winner_id, mock_authenticate):
+        mock_authenticate.return_value = (True, None)
+
         url = reverse('end-match', args=(tournament_id,))
 
         response = self.client.post(
@@ -352,7 +357,10 @@ class AddPointTest(TestCase):
         tournament.status = Tournament.IN_PROGRESS
         tournament.save()
 
-    def add_point(self, tournament_id, player_id):
+    @patch('common.src.jwt_managers.ServiceAccessJWT.authenticate')
+    def add_point(self, tournament_id, player_id, mock_authenticate):
+        mock_authenticate.return_value = (True, None)
+
         url = reverse('add-point', args=(tournament_id,))
 
         response = self.client.post(

--- a/tournament/src/api/views/manage_match_views.py
+++ b/tournament/src/api/views/manage_match_views.py
@@ -12,14 +12,14 @@ from django.views.decorators.csrf import csrf_exempt
 from api import error_message as error
 from api.models import Match, Player, Tournament
 from api.views.match_utils import MatchUtils
+from common.src.jwt_managers import service_authentication
 
 
 @method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(service_authentication(['POST']), name='dispatch')
 class StartMatchView(View):
     @staticmethod
     def post(request: HttpRequest, tournament_id: int) -> JsonResponse:
-        # TODO: add service authentication when implemented
-
         try:
             body = json.loads(request.body.decode('utf8'))
         except Exception:
@@ -90,11 +90,10 @@ class StartMatchView(View):
 
 
 @method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(service_authentication(['POST']), name='dispatch')
 class EndMatchView(View):
     @staticmethod
     def post(request: HttpRequest, tournament_id: int) -> JsonResponse:
-        # TODO: add service authentication when implemented
-
         try:
             body = json.loads(request.body.decode('utf8'))
         except Exception:
@@ -202,10 +201,10 @@ class EndMatchView(View):
 
 
 @method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(service_authentication(['POST']), name='dispatch')
 class AddPointView(View):
     @staticmethod
     def post(request: HttpRequest, tournament_id: int) -> JsonResponse:
-        # TODO: add service authentication when implemented
         try:
             body = json.loads(request.body.decode('utf8'))
         except Exception:


### PR DESCRIPTION
@V-Fries, you must now make an InternalAuthRequest for the following endpoints:
* `POST /tournament/{tournament_id}/match/start/`
* `POST /tournament/{tournament_id}/match/end/`
* `POST /tournament/{tournament_id}/match/add-point/`