### PR TITLE
Deleting errors as objects

### DIFF
--- a/user_management/src/user/views/update_infos.py
+++ b/user_management/src/user/views/update_infos.py
@@ -36,7 +36,7 @@ class UserUpdateInfosManager:
             value = json_request.get(field)
             success, update_errors = UserUpdateInfosManager.update_user_field(user_id, field, value)
             if not success:
-                errors.append({field: update_errors})
+                errors.append(update_errors)
                 return False, errors
 
         return True, None
@@ -51,7 +51,7 @@ class UserUpdateInfosManager:
 
                 valid, error_message = validator(value)
                 if not valid:
-                    errors.append({field: error_message})
+                    errors.append(error_message)
 
     @staticmethod
     def update_user_field(user_id, field_name, new_value):


### PR DESCRIPTION
Errors were returned as objects rather than a list of strings