### PR TITLE
Fix anonymized account being deleted

### DIFF
--- a/user_management/src/user/views/delete_account.py
+++ b/user_management/src/user/views/delete_account.py
@@ -22,7 +22,7 @@ def anonymize_user(user):
     if user.avatar:
         user.avatar.delete()
     user.avatar = None
-    user.emailVerified = False
+    user.emailVerified = True
     user.emailVerificationToken = None
     user.emailVerificationTokenExpiration = None
     user.forgotPasswordCode = None

--- a/user_management/src/user/views/delete_inactive_users.py
+++ b/user_management/src/user/views/delete_inactive_users.py
@@ -44,6 +44,7 @@ def remove_old_pending_accounts():
     try:
         pending_accounts = User.objects.filter(
             emailVerified=False,
+            account_deleted=False,
             date_joined__lt=timezone.now() - timezone.timedelta(
                 days=settings.MAX_DAYS_BEFORE_PENDING_ACCOUNTS_DELETION)
         )


### PR DESCRIPTION
 * Fix anonymized account being deleted from db by CRON `delete_inactive_users.py` (CRON was thinking that those acounts were pending accounts)

## Issue :
CRON `delete_inactive_users.py` was trying to delete : 
```py
User.objects.filter(
            emailVerified=False, ...
```
but when users were deleting their account, `anonymize_user(user)` was also setting `emailVerified=False`.

So the CRON was deleting anonymized accounts from database (leading to front display issue)
<img width="247" alt="Screenshot 2024-03-06 at 03 16 32" src="https://github.com/tdameros/42-transcendence/assets/97832618/08cd357e-3e74-454f-b3af-45a424cfd38a">


## Fix : 
Now, `anonymize_user(user)` set `emailVerified` to `True` (because this really has no effect at all for us)
Furthermore, the CRON `delete_inactive_users.py` now also filter accounts like so : `account_deleted=False`.

It's a double safety, you get it.

