### PR TITLE
remove redirection on logout

### DIFF
--- a/front/app/src/js/components/navbar/ConnectedNavbar.js
+++ b/front/app/src/js/components/navbar/ConnectedNavbar.js
@@ -103,7 +103,6 @@ export class ConnectedNavbar extends Component {
 
   #logout() {
     userManagementClient.logout();
-    getRouter().navigate('/');
   }
 
   #generateNavLink(linkId) {


### PR DESCRIPTION
As the page is now refreshed on disconnection, it is no longer necessary to redirect, as this causes a very ugly flash.