### PR TITLE
fix minimum char in search nav bar

### DIFF
--- a/front/app/src/js/components/navbar/SearchNav.js
+++ b/front/app/src/js/components/navbar/SearchNav.js
@@ -58,7 +58,7 @@ export class SearchNav extends Component {
   }
 
   async #searchBarHandler(event) {
-    if (event.target.value.length < 3) {
+    if (event.target.value.length < 2) {
       this.searchResults.style.display = 'none';
       return;
     }


### PR DESCRIPTION

Currently, you need to enter at least 3 characters in the search bar to find a user. However, it is possible to have a username with only 2 characters. It is therefore impossible to search for users with a 2-character username.

