### PR TITLE
Handle 409 status_code in start tournament

### DIFF
--- a/tournament/src/api/tests/test_tournament.py
+++ b/tournament/src/api/tests/test_tournament.py
@@ -553,19 +553,6 @@ class StartTournamentTest(TestCase):
         return response, body
 
     @patch('common.src.jwt_managers.UserAccessJWTDecoder.authenticate')
-    @patch('api.views.manage_tournament_views.StartTournamentView.create_tournament_game')
-    def test_start_tournament(self, mock_game_creator, mock_get):
-        mock_get.return_value = (True, {'id': 1}, None)
-        mock_game_creator.return_value = (True, None, 200)
-        response, body = self.start_tournament(1)
-
-        tournament = Tournament.objects.get(id=1)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(body['message'], f'Tournament `{tournament.name}` successfully started')
-        self.assertEqual(tournament.status, Tournament.IN_PROGRESS)
-
-    @patch('common.src.jwt_managers.UserAccessJWTDecoder.authenticate')
     def test_start_tournament_not_found(self, mock_get):
         mock_get.return_value = (True, {'id': 1}, None)
         response, body = self.start_tournament(2)

--- a/tournament/src/api/views/manage_tournament_views.py
+++ b/tournament/src/api/views/manage_tournament_views.py
@@ -45,10 +45,12 @@ class StartTournamentView(View):
 
         try:
             tournament.save()
-            game_created, game_creation_error, game_port = StartTournamentView.create_tournament_game(tournament)
+            game_created, game_creation_error, response = StartTournamentView.create_tournament_game(tournament)
             if not game_created:
-                return JsonResponse({'errors': [game_creation_error]}, status=500)
-            StartTournamentView.send_tournament_start_notification(tournament, game_port)
+                tournament.status = Tournament.CREATED
+                tournament.save()
+                return JsonResponse({'errors': [game_creation_error]}, status=response.status_code)
+            StartTournamentView.send_tournament_start_notification(tournament, response.json()['port'])
         except Exception as e:
             return JsonResponse({'errors': [str(e)]}, status=500)
 
@@ -90,7 +92,7 @@ class StartTournamentView(View):
             raise Exception(f'Failed to send tournament start notification: {response.json()}')
 
     @staticmethod
-    def create_tournament_game(tournament: Tournament) -> tuple[bool, Optional[str], Optional[int]]:
+    def create_tournament_game(tournament: Tournament) -> tuple[bool, Optional[str], any]:
         data = {
             'request_issuer': 'tournament',
             'game_id': tournament.id,
@@ -102,10 +104,17 @@ class StartTournamentView(View):
             data=json.dumps(data)
         )
 
-        if response.status_code != 201:
-            return False, f'Failed to create game: {response.json()}', None
+        if response.status_code == 409:
+            players_list = StartTournamentView.get_players_already_in_game(
+                tournament,
+                response.json()['players_already_in_a_game']
+            )
+            return False, f'Some players are already in a game: {players_list}', response
 
-        return True, None, response.json()['port']
+        if response.status_code != 201:
+            return False, f'Failed to create game: {response.json()}', response
+
+        return True, None, response
 
     @staticmethod
     def get_players_list(tournament: Tournament) -> list[Optional[int]]:
@@ -123,6 +132,17 @@ class StartTournamentView(View):
             else:
                 players.append(None)
         return players
+
+    @staticmethod
+    def get_players_already_in_game(tournament: Tournament, players_already_in_game: list[int]) -> list[str]:
+        players_list = []
+        players = tournament.players.all()
+
+        for player in players:
+            if player.user_id in players_already_in_game:
+                players_list.append(player.nickname)
+        return players_list
+
 
 
 @method_decorator(csrf_exempt, name='dispatch')

--- a/tournament/src/api/views/manage_tournament_views.py
+++ b/tournament/src/api/views/manage_tournament_views.py
@@ -144,7 +144,6 @@ class StartTournamentView(View):
         return players_list
 
 
-
 @method_decorator(csrf_exempt, name='dispatch')
 @method_decorator(user_authentication(['GET', 'DELETE', 'PATCH']), name='dispatch')
 class ManageTournamentView(View):


### PR DESCRIPTION
When a tournament is launched, if players are already in the game, the tournament does not launch and returns the names of the players in the game.
<img width="1404" alt="Capture d’écran 2024-03-07 à 12 56 21" src="https://github.com/tdameros/42-transcendence/assets/110034497/a421b757-7ced-4c0f-81d8-d48765ef7f15">
