### PR TITLE
Overhauled the time syncing algorithm

### DIFF
--- a/front/app/src/js/components/game/Engine/_GameSocketIO.js
+++ b/front/app/src/js/components/game/Engine/_GameSocketIO.js
@@ -9,7 +9,7 @@ import {PlayerLocation} from '../Scene/PlayerLocation.js';
 import {sleep} from '../sleep.js';
 import {ErrorPage} from '@utils/ErrorPage.js';
 import {CollisionHandler} from '@components/game/Scene/CollisionHandler.js';
-import {ServerTimeFixer} from '@components/game/ServerTime.js';
+import {ServerTime} from '@components/game/ServerTime.js';
 
 export class _GameSocketIO {
   #engine;
@@ -44,32 +44,12 @@ export class _GameSocketIO {
       },
     });
 
-    this.#socketIO.on('connect', async () => {});
+    this.#socketIO.on('connect', async () => {
+      this.requestTimeSync(Date.now());
+    });
 
     this.#socketIO.on('connect_error', async (jsonString) => {
-      let error;
-      try {
-        error = JSON.parse(jsonString.message);
-      } catch {
-        ToastNotifications.addErrorNotification('Server connection error');
-        this.disconnect();
-        this.#reconnectAttempts++;
-        await sleep(2000);
-        await this.init(URI);
-        return;
-      }
-      if (error['status_code'] === 0 || error['status_code'] === 1) {
-        ToastNotifications.addErrorNotification(error['message']);
-        getRouter().redirect('/');
-        return;
-      } else {
-        console.error('Connection error:', error['message']);
-        ToastNotifications.addErrorNotification(`Connection error: ${error['message']}`);
-        this.disconnect();
-        this.#reconnectAttempts++;
-        await sleep(2000);
-        await this.init(URI);
-      }
+      await this.#connectErrorHandler(jsonString, URI);
     });
 
     this.#socketIO.on('disconnect', () => {
@@ -86,167 +66,226 @@ export class _GameSocketIO {
       console.log('Server debug message: ', message);
     });
 
-    this.#socketIO.on('sync_time', (serverTime) => {
-      ServerTimeFixer.updateServerLatency(serverTime);
+    this.#socketIO.on('time_sync', (timeData) => {
+      ServerTime.syncServerTime(timeData);
     });
 
     this.#socketIO.on('scene', async (data) => {
-      ServerTimeFixer.updateServerLatency(data['server_time']);
-      const scene = new Scene();
-      await scene.init(
-          this.#engine,
-          data['scene'],
-          data['player_location'],
-      );
-      this.#engine.scene = scene;
-      this.#engine.scene.updateCamera();
-      this.#gameHasStarted = data['game_has_started'];
-      if (this.#gameHasStarted) {
-        this.#engine.startListeningForKeyHooks();
-      } else {
-        this.emit('player_is_ready', {});
-        console.log('waiting for other players'); // TODO remove me
-        // TODO display waiting for other players message
-      }
+      await this.#sceneEventHandler(data);
     });
 
     this.#socketIO.on('update_paddle', async (data) => {
-      while (!(this.#engine.scene instanceof Scene)) {
-        await sleep(50);
-      }
-      console.log('update_paddle received');
-
-      const paddle = new PlayerLocation(data['player_location'])
-          .getPlayerFromScene(this.#engine.scene).paddle;
-      paddle.setDirection(data['direction']);
-      paddle.setPosition(data['position']);
+      await this.#updatePaddleEventHandler(data);
     });
 
     this.#socketIO.on('prepare_ball_for_match', async (data) => {
-      while (!(this.#engine.scene instanceof Scene)) {
-        await sleep(50);
-      }
-      console.log('prepare_ball_for_match received');
-
-      if (!this.#gameHasStarted) {
-        this.#gameHasStarted = true;
-        this.#engine.startListeningForKeyHooks();
-        console.log('Game is starting'); // TODO remove me
-        // TODO remove waiting for other players message
-      }
-
-      const match = this.#engine.scene
-          .getMatchFromLocation(data['match_location']);
-      match.prepare_ball_for_match(
-          ServerTimeFixer.fixServerTime(data['ball_start_time']),
-          data['ball_movement'],
-      );
+      await this.#prepareBallForMatchEventHandler(data);
     });
 
     this.#socketIO.on('update_ball', async (data) => {
-      while (!(this.#engine.scene instanceof Scene)) {
-        await sleep(50);
-      }
-      console.log('update_ball received');
-
-      const match = this.#engine.scene
-          .getMatchFromLocation(data['match_location']);
-      const movement = data['movement'];
-      match.setBallMovement(movement);
-      match.setBallPosition(data['position']);
-
-      const paddle = movement['x'] < 0. ?
-          match.players[0].paddle :
-          match.players[1].paddle;
-      const timeAtUpdate = ServerTimeFixer
-          .fixServerTime(data['time_at_update']);
-      const now = Date.now();
-      if (timeAtUpdate >= now) {
-        return;
-      }
-      const timeDelta = (now - timeAtUpdate) / 1000.;
-      new CollisionHandler(paddle, this.#engine.scene.boardSize)
-          .updateBallPositionAndMovement(timeDelta, match);
+      await this.#updateBallEventHandler(data);
     });
 
     this.#socketIO.on('player_won_match', async (data) => {
-      while (!(this.#engine.scene instanceof Scene)) {
-        await sleep(50);
-      }
-      console.log('player_won_match received');
-
-      const winnerIndex = data['winner_index'];
-      const finishedMatchLocation = data['finished_match_location'];
-      this.#engine.scene.removeLooserFromMatch(finishedMatchLocation,
-          1 - winnerIndex);
-
-      const winner = this.#engine.scene
-          .getMatchFromLocation(finishedMatchLocation)
-          .players[winnerIndex];
-
-      const newMatchJson = data['new_match_json'];
-      await this.#engine.scene.createMatchIfDoesntExist(newMatchJson);
-
-      const newWinnerIndex = finishedMatchLocation['match'] % 2;
-      this.#engine.scene.addWinnerToMatch(
-          newMatchJson['location'], winner, winnerIndex, newWinnerIndex,
-      );
-      winner.resetPoints();
-
-      this.#engine.scene.deleteMatch(finishedMatchLocation);
-
-      this.#engine.scene.updateCamera();
+      await this.#playerWonMatchEventHandler(data);
     });
 
     this.#socketIO.on('player_scored_a_point', async (data) => {
-      while (!(this.#engine.scene instanceof Scene)) {
-        await sleep(50);
-      }
-
-      const playerLocation = new PlayerLocation(data['player_location']);
-      const match = playerLocation.getPlayerMatchFromScene(this.#engine.scene);
-      match.players[playerLocation.playerIndex].addPoint();
+      await this.#playerScoredAPointEventHandler(data);
     });
 
     this.#socketIO.on('game_over', async (data) => {
-      while (!(this.#engine.scene instanceof Scene)) {
-        await sleep(50);
-      }
-      console.log('game_over received');
-
-      const winnerIndex = data['winner_index'];
-      this.#engine.scene.matches[0].players[winnerIndex].addPoint();
-
-      const currentPlayerLocation = this.#engine.scene.currentPlayerLocation;
-      if (currentPlayerLocation.isLooser) {
-        this.#handleGameOverPlayerHasNotReachedTheFinal();
-        return;
-      }
-
-      const finalMatch = currentPlayerLocation.getPlayerMatchFromScene(
-          this.#engine.scene);
-      const winnerScore = finalMatch.players[winnerIndex].score;
-      const looserScore = finalMatch.players[1 - winnerIndex].score;
-
-      if (currentPlayerLocation.playerIndex === winnerIndex) {
-        if (this.#engine.scene.loosers.length !== 0) {
-          this.#handleGameOverPlayerWonTournamentFinal(winnerScore,
-              looserScore);
-          return;
-        }
-        this.#handleGameOverPlayerWon1v1(winnerScore, looserScore);
-        return;
-      }
-
-      if (this.#engine.scene.loosers.length !== 0) {
-        this.#handleGameOverPlayerLostTournamentFinal(winnerScore,
-            looserScore);
-        return;
-      }
-      this.#handleGameOverPlayerLost1v1(winnerScore, looserScore);
+      await this.#gameOverEventHandler(data);
     });
 
     this.#socketIO.connect();
+  }
+
+  requestTimeSync(currentTime) {
+    this.emit('request_time_sync', currentTime);
+  }
+
+  async #connectErrorHandler(jsonString, URI) {
+    let error;
+    try {
+      error = JSON.parse(jsonString.message);
+    } catch {
+      ToastNotifications.addErrorNotification('Server connection error');
+      this.disconnect();
+      this.#reconnectAttempts++;
+      await sleep(2000);
+      await this.init(URI);
+      return;
+    }
+    if (error['status_code'] === 0 || error['status_code'] === 1) {
+      ToastNotifications.addErrorNotification(error['message']);
+      getRouter().redirect('/');
+      return;
+    } else {
+      console.error('Connection error:', error['message']);
+      ToastNotifications.addErrorNotification(`Connection error: ${error['message']}`);
+      this.disconnect();
+      this.#reconnectAttempts++;
+      await sleep(2000);
+      await this.init(URI);
+    }
+  }
+
+  async #sceneEventHandler(data) {
+    while (!ServerTime.isTimeSynced) {
+      await sleep(5);
+    }
+    const scene = new Scene();
+    await scene.init(
+        this.#engine,
+        data['scene'],
+        data['player_location'],
+    );
+    this.#engine.scene = scene;
+    this.#engine.scene.updateCamera();
+    this.#engine.displayGameScene();
+    this.#gameHasStarted = data['game_has_started'];
+    if (this.#gameHasStarted) {
+      this.#engine.startListeningForKeyHooks();
+    } else {
+      this.emit('player_is_ready', {});
+      console.log('waiting for other players'); // TODO remove me
+      // TODO display waiting for other players message
+    }
+  }
+
+  async #updatePaddleEventHandler(data) {
+    while (!(this.#engine.scene instanceof Scene)) {
+      await sleep(50);
+    }
+    console.log('update_paddle received');
+
+    const paddle = new PlayerLocation(data['player_location'])
+        .getPlayerFromScene(this.#engine.scene).paddle;
+    paddle.setDirection(data['direction']);
+    paddle.setPosition(data['position']);
+  }
+
+  async #prepareBallForMatchEventHandler(data) {
+    while (!(this.#engine.scene instanceof Scene)) {
+      await sleep(50);
+    }
+    console.log('prepare_ball_for_match received');
+
+    if (!this.#gameHasStarted) {
+      this.#gameHasStarted = true;
+      this.#engine.startListeningForKeyHooks();
+      console.log('Game is starting'); // TODO remove me
+      // TODO remove waiting for other players message
+    }
+
+    const match = this.#engine.scene
+        .getMatchFromLocation(data['match_location']);
+    match.prepare_ball_for_match(
+        ServerTime.fixServerTime(data['ball_start_time']),
+        data['ball_movement'],
+    );
+  }
+
+  async #updateBallEventHandler(data) {
+    while (!(this.#engine.scene instanceof Scene)) {
+      await sleep(50);
+    }
+    console.log('update_ball received');
+
+    const match = this.#engine.scene
+        .getMatchFromLocation(data['match_location']);
+    const movement = data['movement'];
+    match.setBallMovement(movement);
+    match.setBallPosition(data['position']);
+
+    const paddle = movement['x'] < 0. ?
+        match.players[0].paddle :
+        match.players[1].paddle;
+    const timeAtUpdate = ServerTime.fixServerTime(data['time_at_update']);
+    const now = Number(Date.now());
+    const timeDelta = (now - timeAtUpdate + ServerTime.latency) / 1000.;
+    if (timeDelta > 0.) {
+      new CollisionHandler(paddle, this.#engine.scene.boardSize)
+          .updateBallPositionAndMovement(timeDelta, match);
+    }
+  }
+
+  async #playerWonMatchEventHandler(data) {
+    while (!(this.#engine.scene instanceof Scene)) {
+      await sleep(50);
+    }
+    console.log('player_won_match received');
+
+    const winnerIndex = data['winner_index'];
+    const finishedMatchLocation = data['finished_match_location'];
+    this.#engine.scene.removeLooserFromMatch(finishedMatchLocation,
+        1 - winnerIndex);
+
+    const winner = this.#engine.scene
+        .getMatchFromLocation(finishedMatchLocation)
+        .players[winnerIndex];
+
+    const newMatchJson = data['new_match_json'];
+    await this.#engine.scene.createMatchIfDoesntExist(newMatchJson);
+
+    const newWinnerIndex = finishedMatchLocation['match'] % 2;
+    this.#engine.scene.addWinnerToMatch(
+        newMatchJson['location'], winner, winnerIndex, newWinnerIndex,
+    );
+    winner.resetPoints();
+
+    this.#engine.scene.deleteMatch(finishedMatchLocation);
+
+    this.#engine.scene.updateCamera();
+  }
+
+  async #playerScoredAPointEventHandler(data) {
+    while (!(this.#engine.scene instanceof Scene)) {
+      await sleep(50);
+    }
+
+    const playerLocation = new PlayerLocation(data['player_location']);
+    const match = playerLocation.getPlayerMatchFromScene(this.#engine.scene);
+    match.players[playerLocation.playerIndex].addPoint();
+  }
+
+  async #gameOverEventHandler(data) {
+    while (!(this.#engine.scene instanceof Scene)) {
+      await sleep(50);
+    }
+    console.log('game_over received');
+
+    const winnerIndex = data['winner_index'];
+    this.#engine.scene.matches[0].players[winnerIndex].addPoint();
+
+    const currentPlayerLocation = this.#engine.scene.currentPlayerLocation;
+    if (currentPlayerLocation.isLooser) {
+      this.#handleGameOverPlayerHasNotReachedTheFinal();
+      return;
+    }
+
+    const finalMatch = currentPlayerLocation.getPlayerMatchFromScene(
+        this.#engine.scene);
+    const winnerScore = finalMatch.players[winnerIndex].score;
+    const looserScore = finalMatch.players[1 - winnerIndex].score;
+
+    if (currentPlayerLocation.playerIndex === winnerIndex) {
+      if (this.#engine.scene.loosers.length !== 0) {
+        this.#handleGameOverPlayerWonTournamentFinal(winnerScore,
+            looserScore);
+        return;
+      }
+      this.#handleGameOverPlayerWon1v1(winnerScore, looserScore);
+      return;
+    }
+
+    if (this.#engine.scene.loosers.length !== 0) {
+      this.#handleGameOverPlayerLostTournamentFinal(winnerScore,
+          looserScore);
+      return;
+    }
+    this.#handleGameOverPlayerLost1v1(winnerScore, looserScore);
   }
 
   #handleGameOverPlayerHasNotReachedTheFinal() {

--- a/front/app/src/js/components/game/Scene/Match.js
+++ b/front/app/src/js/components/game/Scene/Match.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 
 import {Player} from './Player/Player';
 import {Ball} from './Ball';
-import {ServerTimeFixer} from '@components/game/ServerTime.js';
+import {ServerTime} from '@components/game/ServerTime.js';
 
 export class Match {
   #threeJSGroup = new THREE.Group();
@@ -16,7 +16,7 @@ export class Match {
   async init(matchJson, shouldCreatePlayers, pointsToWinMatch) {
     this.#ball = new Ball(matchJson['ball']);
     this.#ballIsWaiting = matchJson['ball_is_waiting'];
-    this.#ballStartTime = ServerTimeFixer.fixServerTime(
+    this.#ballStartTime = ServerTime.fixServerTime(
         matchJson['ball_start_time']);
 
     const position = matchJson['position'];

--- a/front/app/src/js/components/game/Scene/Player/_Board.js
+++ b/front/app/src/js/components/game/Scene/Player/_Board.js
@@ -155,7 +155,7 @@ export class _Board {
   }
 
   updateFrame() {
-    const currentTime = Date.now();
+    const currentTime = Number(Date.now());
     const frequency = 300;
     const amplitude = 0.3;
     this.#points.forEach((point, index) => {

--- a/front/app/src/js/components/game/Scene/Scene.js
+++ b/front/app/src/js/components/game/Scene/Scene.js
@@ -79,8 +79,7 @@ export class Scene {
     this.#sky.setDarkTheme();
   }
 
-  updateFrame(timeDelta) {
-    const currentTime = Date.now();
+  updateFrame(currentTime, timeDelta) {
     for (const match of this.#matches) {
       match.updateFrame(
           timeDelta,

--- a/front/app/src/js/components/game/ServerTime.js
+++ b/front/app/src/js/components/game/ServerTime.js
@@ -1,30 +1,74 @@
-export class ServerTimeFixer {
+export class ServerTime {
+  static #isTimeSynced = false;
+
+  // Used to account for when the client and server do not have the same
+  // system date
   static #timeOffsetSum = 0.;
-  static #divider = 0.;
+  static #offsetDivider = 0.;
   static #timeOffsetsSize = 20;
-  static #timeOffsets = Array(ServerTimeFixer.#timeOffsetsSize).fill(0.);
+  static #timeOffsets = Array(ServerTime.#timeOffsetsSize).fill(0.);
   static #timeOffsetsIndex = 0;
   static #averageTimeOffset = 0.;
 
-  static updateServerLatency(serverCurrentTime) {
-    const currentTimeOffset = Date.now() -
-        ServerTimeFixer.#convertTime(serverCurrentTime);
+  // Used to account for latency
+  static #latencySum = 0.;
+  static #latencyDivider = 0.;
+  static #latenciesSize = 20;
+  static #latencies = Array(ServerTime.#latenciesSize).fill(0.);
+  static #latenciesIndex = 0;
+  static #averageLatency = 0.;
 
-    this.#timeOffsetSum += currentTimeOffset;
-    this.#timeOffsetSum -= this.#timeOffsets[this.#timeOffsetsIndex];
-    this.#timeOffsets[this.#timeOffsetsIndex] = currentTimeOffset;
-    this.#timeOffsetsIndex = (this.#timeOffsetsIndex + 1) %
-        this.#timeOffsetsSize;
+  static syncServerTime(timeData) {
+    const clientCurrentTime = Number(Date.now());
+    const clientTimeAtRequestEmit = Number(timeData['time1']);
+    const serverTimeAtRequestReceive = this.#secondsToMs(timeData['time2']);
 
-    this.#divider = Math.min(this.#divider + 1., this.#timeOffsetsSize);
-    this.#averageTimeOffset = this.#timeOffsetSum / this.#divider;
+    const latency = (clientCurrentTime - clientTimeAtRequestEmit) / 2.;
+    const timeOffset = clientCurrentTime - serverTimeAtRequestReceive - latency;
+
+    this.#updateLatency(latency);
+    this.#updateTimeOffset(timeOffset);
+
+    this.#isTimeSynced = true;
   }
 
   static fixServerTime(serverTime) {
-    return this.#convertTime(serverTime) + this.#averageTimeOffset;
+    return this.#secondsToMs(serverTime) + this.#averageTimeOffset;
   }
 
-  static #convertTime(serverTime) {
+  static get latency() {
+    return this.#averageLatency;
+  }
+
+  static get isTimeSynced() {
+    return this.#isTimeSynced;
+  }
+
+  static #secondsToMs(serverTime) {
     return serverTime * 1000.;
+  }
+
+  static #updateLatency(latency) {
+    this.#latencySum += latency;
+    this.#latencySum -= this.#latencies[this.#latenciesIndex];
+    this.#latencies[this.#latenciesIndex] = latency;
+    this.#latenciesIndex = (this.#latenciesIndex + 1) %
+      this.#timeOffsetsSize;
+
+    this.#latencyDivider = Math.min(
+        this.#latencyDivider + 1, this.#latenciesSize);
+    this.#averageLatency = this.#latencySum / this.#latencyDivider;
+  }
+
+  static #updateTimeOffset(timeOffset) {
+    this.#timeOffsetSum += timeOffset;
+    this.#timeOffsetSum -= this.#timeOffsets[this.#timeOffsetsIndex];
+    this.#timeOffsets[this.#timeOffsetsIndex] = timeOffset;
+    this.#timeOffsetsIndex = (this.#timeOffsetsIndex + 1) %
+      this.#timeOffsetsSize;
+
+    this.#offsetDivider = Math.min(
+        this.#offsetDivider + 1, this.#timeOffsetsSize);
+    this.#averageTimeOffset = this.#timeOffsetSum / this.#offsetDivider;
   }
 }

--- a/front/app/src/js/components/game/game.js
+++ b/front/app/src/js/components/game/game.js
@@ -1,6 +1,4 @@
 import WebGL from 'three/addons/capabilities/WebGL.js';
-import * as THREE from 'three';
-import TWEEN from '@tweenjs/tween.js';
 
 import {Component} from '@components';
 import {ToastNotifications} from '@components/notifications';

--- a/front/app/src/js/components/game/game.js
+++ b/front/app/src/js/components/game/game.js
@@ -1,5 +1,4 @@
 import WebGL from 'three/addons/capabilities/WebGL.js';
-import * as THREE from 'three';
 
 import {Component} from '@components';
 import {ToastNotifications} from '@components/notifications';
@@ -8,7 +7,6 @@ import {getRouter} from '@js/Router.js';
 
 import {Engine} from './Engine/Engine.js';
 import {Theme} from '@js/Theme.js';
-import TWEEN from '@tweenjs/tween.js';
 
 export class Game extends Component {
   static gameURL = `https://${window.location.hostname}`;
@@ -151,24 +149,11 @@ export class Game extends Component {
     }
     this.engine = new Engine(this);
 
-    this.displayScene(this.engine);
+    this.engine.displayLoadingScene();
     this.engine.connectToServer(URI)
         .catch((error) => {
           console.error('Error connecting to server:', error);
         });
-  }
-
-  displayScene(engine) {
-    const clock = new THREE.Clock();
-
-    engine.setAnimationLoop(() => {
-      const delta = clock.getDelta();
-      engine.scene.updateFrame(delta);
-
-      TWEEN.update();
-      engine.threeJS.updateControls();
-      engine.renderFrame();
-    });
   }
 
   getGameURL(port) {

--- a/front/doc/pong.md
+++ b/front/doc/pong.md
@@ -19,12 +19,15 @@
   >> ```
   >
   >> Prints debug_message on `console.log`
- 
-- ### `sync_time`:
+
+- ### `time_sync`:
   >> Argument:
   >> ```
-  >> 'server_time': float (Seconds since the Epoch)
-  >> ```
+  >> {
+  >>     'time1': time1 (value sent during `request_time_sync` event),
+  >>     'time2': float (Seconds since the Epoch on server side)
+  >> }
+  >> ``` 
   >
   >> Allows the client to adapt to latency
 
@@ -95,7 +98,6 @@
   >>         'player_index': int
   >>     }
   >>     'game_has_started': bool,
-  >>     'server_time': float (Seconds since the Epoch)
   >> }
   >> ```
   >

--- a/pong_server/doc/game_server.md
+++ b/pong_server/doc/game_server.md
@@ -22,7 +22,21 @@
 - ### `player_is_ready`:
   > Must be sent once the scene is loaded by the client
 
-- ### `update_player`:
+- ### `request_time_sync`:
+  >> Argument:
+  >> ```
+  >> time1: any
+  >> ``` 
+  >
+  >> Response: Event `time_sync`
+  >> ```
+  >> {
+  >>     'time1': time1 (same as the given argument),
+  >>     'time2': float (Seconds since the Epoch on server side)
+  >> }
+  >> ``` 
+
+- ### `update_paddle`:
   >> Argument:
   >> ```
   >> {

--- a/pong_server/src/game_server/EventEmitter.py
+++ b/pong_server/src/game_server/EventEmitter.py
@@ -12,8 +12,11 @@ from vector_to_dict import vector_to_dict
 
 class EventEmitter(object):
     @staticmethod
-    async def sync_time(current_time: float):
-        await Server.emit('sync_time', rooms.ALL_PLAYERS, current_time)
+    async def time_sync(sid, time1: any):
+        await Server.emit('time_sync', sid, {
+            'time1': time1,
+            'time2': time.time()
+        })
 
     @staticmethod
     async def scene(sid: str,
@@ -24,7 +27,6 @@ class EventEmitter(object):
             'scene': scene,
             'player_location': player_location.to_json(),
             'game_has_started': game_has_started,
-            'server_time': time.time()
         })
 
     @staticmethod

--- a/pong_server/src/game_server/EventHandler.py
+++ b/pong_server/src/game_server/EventHandler.py
@@ -16,6 +16,7 @@ class EventHandler(object):
         Server.sio.on('connect')(EventHandler._connect)
         Server.sio.on('disconnect')(EventHandler._disconnect)
         Server.sio.on('player_is_ready')(EventHandler._player_is_ready)
+        Server.sio.on('request_time_sync')(EventHandler._request_time_sync)
         Server.sio.on('update_paddle')(EventHandler._update_paddle)
 
     @staticmethod
@@ -64,6 +65,12 @@ class EventHandler(object):
     @staticmethod
     async def _player_is_ready(sid: str, _data):
         ClientManager.add_ready_player(ClientManager.get_user_id(sid))
+
+    @staticmethod
+    async def _request_time_sync(sid: str, time1):
+        # No need to check time1 type as the server only sends it back to the client without
+        # using it
+        await EventEmitter.time_sync(sid, time1)
 
     @staticmethod
     async def _update_paddle(sid: str, player_data):

--- a/pong_server/src/game_server/Game/GameManager.py
+++ b/pong_server/src/game_server/Game/GameManager.py
@@ -89,12 +89,8 @@ class GameManager(object):
     @staticmethod
     async def game_loop():
         clock = Clock()
-        current_time, time_delta = clock.get_time()
-        next_sync = current_time
         while True:
-            if current_time >= next_sync:
-                await EventEmitter.sync_time(current_time)
-                next_sync = current_time + 1.  # Sync every second
+            current_time, time_delta = clock.get_time()
             finished_matches: list[Match] = []
 
             for match in GameManager._matches:
@@ -108,8 +104,6 @@ class GameManager(object):
             await Server.sio.sleep(0.01)
             if GameManager._is_game_over:
                 return
-
-            current_time, time_delta = clock.get_time()
 
     @staticmethod
     async def match_was_won(match: Match):


### PR DESCRIPTION
Client can now differentiate latency and bad system time sync

Client sends a `request_time_sync` event to the server:
```
Argument:
time1: Date.now()
```
Server receives the event and sends a `time_sync` event to the client:
```
Argument:
{
    time1: time1 (Copy of the argument given by the client),
    time2: time.time()
}
```
Client receives the event and can now calculate how long the server took to receive the event and send back it's own:
```
fullLatency = Date.now() - time1
oneWayLatency = fullLatency / 2.
```
Client can also get the difference in system time compared to the server:
```
timeOffset = Date.now() - time2 - oneWayLatency
```
So now when the server sends a timestamp the client can translate it to the client's system time:
```
fixedTimestamp = timestamp + timeOffset
```

As latency can be variable this process is repeated every 2 seconds and averaged over the last 20 requests