### PR TITLE
500 oauth

### DIFF
--- a/user_management/src/user/views/oauth.py
+++ b/user_management/src/user/views/oauth.py
@@ -121,12 +121,14 @@ class OAuthCallback(View):
             self.auth_supported = True
 
     def get(self, request, auth_service):
-        if request.GET.get('error'):
-            return redirect(f'{self.get_source_url(request.GET.get("state"))}?error='
-                            f'Could not authenticate with {auth_service}')
         code = request.GET.get('code')
         state = request.GET.get('state')
         source, errors = self.get_source_url(state)
+        if request.GET.get('error'):
+            if source is None:
+                source = settings.FRONT_URL + 'signin/'
+            return redirect(f'{source}?error='
+                            f'Could not authenticate with {auth_service}')
         self.set_params(auth_service)
         if not source or self.auth_supported is False:
             source = settings.FRONT_URL

--- a/user_management/src/user/views/oauth.py
+++ b/user_management/src/user/views/oauth.py
@@ -62,6 +62,11 @@ class OAuth(View):
     @staticmethod
     def get(request, auth_service):
         source = request.GET.get('source')
+        error = request.GET.get('error')
+        if error:
+            if not source:
+                source = settings.FRONT_URL + 'signin/'
+            return redirect(f'{source}?error=Could not authenticate : {error}')
         if source is None:
             return JsonResponse(data={'errors': ['No source provided']}, status=400)
         if not source.endswith('/'):


### PR DESCRIPTION
# fix 500 : 
When a user was denying 42api OAuth, this caused a uncontrolled redirect url.
```py
    def get(self, request, auth_service):
        if request.GET.get('error'):
            return redirect(f'{self.get_source_url(request.GET.get("state"))}?error='
                            f'Could not authenticate with {auth_service}')
```
but get_source_url() was recently updated d3e4c6be4d6bec8d6c47486154c723fd49ed1e63 to return an error

