### PR TITLE
check if the field the user wants to change authorized

### DIFF
--- a/user_management/src/user/views/update_infos.py
+++ b/user_management/src/user/views/update_infos.py
@@ -33,6 +33,9 @@ class UserUpdateInfosManager:
             return False, errors
 
         for field in change_list:
+            if field not in UserUpdateInfosManager.FIELD_VALIDATORS.keys():
+                errors.append(f'Field {field} is not valid')
+                return False, errors
             value = json_request.get(field)
             success, update_errors = UserUpdateInfosManager.update_user_field(user_id, field, value)
             if not success:


### PR DESCRIPTION
# `POST /user/update-infos/`

## issue : 
if you use postman, you could change an attribute of your account that you were not supposed to change.
For example, you could increase your elo.

## fix :
in `POST /user/update-infos/`, all fields are now checked if they are in the fields a user is authorized to change
( username, password, email..)
